### PR TITLE
[FIX]: Added missing .enable option

### DIFF
--- a/config/advanced.yml.in
+++ b/config/advanced.yml.in
@@ -34,7 +34,7 @@ steps:
     - AppImage:
         description: _("Enable AppImage support by installing the \"appimage-run\" package. For AppImages to work, you must run them with the \"appimage-run\" command.")
         config: |-
-          modules.packagemanagers.appimage = true;
+          modules.packagemanagers.appimage.enable = true;
 - !list
   multiple: false
   required: true


### PR DESCRIPTION
Added missing enable option on appimage. Before it was occured the error: [link](https://pastebin.com/0gHJY5Fb)

Now, it's fixed as in modules: [link](https://github.com/xinux-org/modules/blob/1cc37e65be440e7ef4b7e0a8099cb01cbde50524/modules/nixos/packagemanagers/default.nix#L12)